### PR TITLE
Jump to captain and enable scheduling on aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,24 @@ GDB has built-in support for QEMU, but it doesn't play nicely with OSes that run
     ```
     QEMU will be paused until we move the debugger forward, with standard GDB commands like `n` to step through the next instruction or `c` to continue execution. Any standard GDB commands will now work.
 
+### Connecting GDB to aarch64 Theseus on QEMU
+We don't yet have a patched version of GDB for aarch64 targets, but we can use the existing `gdb-multiarch` package to 
+
+1. Install the required package:
+    ```sh
+    sudo apt-get install gdb-multiarch
+    ```
+
+2. Build Theseus for aarch64 and run it in QEMU:
+    ```sh
+    make ARCH=aarch64 FEATURES= CROSS=aarch64-linux-gnu- run ## or use `run_pause`
+    ```
+3. In another terminal window, run the following to start GDB and attach it to the running QEMU instance:
+    ```sh
+    gdb-multiarch -ex "target remote :1234"
+    ```
+
+4. Within GDB, symbols aren't yet supported, but you can view assembly code with `layout asm` and set breakpoints on virtual addresses.
 
 ## IDE Setup  
 Our personal preference is to use VS Code, which has excellent cross-platform support for Rust. Other options are available [here](https://areweideyet.com/).

--- a/kernel/acpi/madt/src/lib.rs
+++ b/kernel/acpi/madt/src/lib.rs
@@ -162,6 +162,9 @@ impl<'t> Iterator for MadtIter<'t> {
                     ENTRY_TYPE_LOCAL_APIC_ADDRESS_OVERRIDE if entry_size == size_of::<MadtLocalApicAddressOverride>() => {
                         self.mapped_pages.as_type(self.offset).ok().map(MadtEntry::LocalApicAddressOverride)
                     },
+                    ENTRY_TYPE_LOCAL_X2APIC if entry_size == size_of::<MadtLocalX2Apic>() => {
+                        self.mapped_pages.as_type(self.offset).ok().map(MadtEntry::LocalX2Apic)
+                    },
                     _ => None,
                 };
                 // move the offset to the end of this entry, i.e., the beginning of the next entry record
@@ -202,6 +205,8 @@ const ENTRY_TYPE_INT_SRC_OVERRIDE:            u8 = 2;
 // entry type 3 doesn't exist
 const ENTRY_TYPE_NON_MASKABLE_INTERRUPT:      u8 = 4;
 const ENTRY_TYPE_LOCAL_APIC_ADDRESS_OVERRIDE: u8 = 5;
+// entry types 6, 7, 8 are not used
+const ENTRY_TYPE_LOCAL_X2APIC:                u8 = 9;
 
 
 /// The set of possible MADT Entries.
@@ -217,6 +222,8 @@ pub enum MadtEntry<'t> {
     NonMaskableInterrupt(&'t MadtNonMaskableInterrupt),
     /// A Local APIC Address Override MADT entry.
     LocalApicAddressOverride(&'t MadtLocalApicAddressOverride),
+    /// A Local X2APIC MADT entry.
+    LocalX2Apic(&'t MadtLocalX2Apic),
     /// The MADT table had an entry of an unknown type or mismatched length,
     /// so the table entry was malformed and unusable.
     /// The entry type ID is included.
@@ -303,6 +310,22 @@ pub struct MadtLocalApicAddressOverride {
 const _: () = assert!(core::mem::size_of::<MadtLocalApicAddressOverride>() == 12);
 const _: () = assert!(core::mem::align_of::<MadtLocalApicAddressOverride>() == 1);
 
+/// MADT Local X2APIC
+#[derive(Copy, Clone, Debug, FromBytes)]
+#[repr(packed)]
+pub struct MadtLocalX2Apic {
+    _header: EntryRecord,
+    _reserved: u16,
+    /// Processor ID
+    pub processor: u32,
+    /// Flags. 1 means that the processor is enabled
+    pub flags: u32,
+    /// Local X2APIC ID
+    pub x2apic_id: u32,
+}
+const _: () = assert!(core::mem::size_of::<MadtLocalX2Apic>() == 16);
+const _: () = assert!(core::mem::align_of::<MadtLocalX2Apic>() == 1);
+
 /// Handles the BSP's (bootstrap processor, the first core to boot) entry in the given MADT iterator.
 /// This should be the first function invoked to initialize the BSP information, 
 /// and should come before any other entries in the MADT are handled.
@@ -311,11 +334,11 @@ fn handle_bsp_lapic_entry(madt_iter: MadtIter, page_table: &mut PageTable) -> Re
 
     for madt_entry in madt_iter.clone() {
         if let MadtEntry::LocalApic(lapic_entry) = madt_entry { 
-            let (nmi_lint, nmi_flags) = find_nmi_entry_for_processor(lapic_entry.processor, madt_iter.clone());
+            let (nmi_lint, nmi_flags) = find_nmi_entry_for_processor(lapic_entry.processor as u32, madt_iter.clone());
 
             match LocalApic::init(
                 page_table,
-                lapic_entry.processor,
+                lapic_entry.processor as u32,
                 None, // we don't know the hardware-assigned APIC ID of the BSP (this CPU) yet
                 true,
                 nmi_lint,
@@ -395,12 +418,12 @@ fn handle_ioapic_entries(madt_iter: MadtIter, page_table: &mut PageTable) -> Res
 /// Finds the Non-Maskable Interrupt (NMI) entry in the MADT ACPI table (i.e., the given `MadtIter`)
 /// corresponding to the given processor. 
 /// If no entry exists, it returns the default NMI entry value: `(lint = 1, flags = 0)`.
-pub fn find_nmi_entry_for_processor(processor: u8, madt_iter: MadtIter) -> (u8, u16) {
+pub fn find_nmi_entry_for_processor(processor: u32, madt_iter: MadtIter) -> (u8, u16) {
     for madt_entry in madt_iter {
         if let MadtEntry::NonMaskableInterrupt(nmi) = madt_entry {
             // NMI entries are based on the "processor" id, not the "apic_id"
             // Return this Nmi entry if it's for the given lapic, or if it's for all lapics
-            if nmi.processor == processor || nmi.processor == 0xFF  {
+            if nmi.processor as u32 == processor || nmi.processor == 0xFF  {
                 return (nmi.lint, nmi.flags);
             }
         }

--- a/kernel/ap_start/src/lib.rs
+++ b/kernel/ap_start/src/lib.rs
@@ -35,7 +35,7 @@ pub fn insert_ap_stack(cpu_id: u32 , stack: Stack) {
 /// Entry to rust for an AP.
 /// The arguments must match the invocation order in "ap_boot.asm"
 pub fn kstart_ap(
-    processor_id: u8,
+    processor_id: u32,
     cpu_id: CpuId,
     _stack_start: VirtualAddress,
     _stack_end: VirtualAddress,

--- a/kernel/apic/src/lib.rs
+++ b/kernel/apic/src/lib.rs
@@ -420,7 +420,7 @@ pub struct LocalApic {
     apic_id: ApicId,
     /// The processor ID of this APIC (from the `MADT` ACPI table entry).
     /// This is currently not used for anything in Theseus.
-    processor_id: u8,
+    processor_id: u32,
     /// Whether this Local APIC is the BootStrap Processor (the first CPU to boot up).
     is_bootstrap_cpu: bool,
     /// The value that should be written to the APIC timer's initial count register
@@ -468,7 +468,7 @@ impl LocalApic {
     /// the BSP cannot invoke this for other APs.
     pub fn init(
         page_table: &mut PageTable,
-        processor_id: u8,
+        processor_id: u32,
         expected_apic_id: Option<u32>,
         should_be_bsp: bool,
         nmi_lint: u8,
@@ -558,7 +558,7 @@ impl LocalApic {
     /// 
     /// This value comes from the `MADT` ACPI table entry that was used
     /// to boot up this CPU core.
-    pub fn processor_id(&self) -> u8 { self.processor_id }
+    pub fn processor_id(&self) -> u32 { self.processor_id }
 
     /// Returns `true` if this CPU core was the BootStrap Processor (BSP),
     /// i.e., the first CPU to boot and run the OS code.
@@ -644,7 +644,7 @@ impl LocalApic {
             }
             LapicType::XApic(regs) => {
                 regs.timer_divide.write(LapicTimerDivide::By16.as_register_value());
-                regs.timer_initial_count.write(INITIAL_COUNT as u32);
+                regs.timer_initial_count.write(INITIAL_COUNT);
 
                 // wait for the given period using the PIT clock
                 pit_wait(microseconds).unwrap();
@@ -686,7 +686,7 @@ impl LocalApic {
                 regs.timer_divide.write(LapicTimerDivide::By16.as_register_value());
                 // map APIC timer to an interrupt handler in the IDT
                 regs.lvt_timer.write(LOCAL_APIC_LVT_IRQ as u32 | APIC_TIMER_MODE_PERIODIC); 
-                regs.timer_initial_count.write(apic_period as u32); 
+                regs.timer_initial_count.write(apic_period); 
 
                 regs.lvt_thermal.write(0);
                 regs.lvt_error.write(0);

--- a/kernel/app_io/src/lib.rs
+++ b/kernel/app_io/src/lib.rs
@@ -12,7 +12,8 @@
 #![no_std]
 
 extern crate alloc;
-extern crate logger_x86_64 as logger;
+#[cfg(target_arch = "x86_64")]
+extern crate logger_x86_64;
 
 use alloc::{format, sync::Arc};
 use core2::io::{self, Error, ErrorKind, Read, Write};
@@ -215,9 +216,10 @@ pub fn print_to_stdout_args(fmt_args: core::fmt::Arguments) {
                 .write_all(format!("{fmt_args}").as_bytes())
                 .is_err()
             {
-                let _ = logger::write_str("\x1b[31m [E] failed to write to stdout \x1b[0m\n");
+                #[cfg(target_arch = "x86_64")]
+                let _ = logger_x86_64::write_str("\x1b[31m [E] failed to write to stdout \x1b[0m\n");
             }
     } else {
-        // let _ = logger::write_str("\x1b[31m [E] error in print!/println! macro: no stdout queue for current task \x1b[0m\n");
+        // let _ = logger_x86_64::write_str("\x1b[31m [E] error in print!/println! macro: no stdout queue for current task \x1b[0m\n");
     };
 }

--- a/kernel/captain/Cargo.toml
+++ b/kernel/captain/Cargo.toml
@@ -8,102 +8,43 @@ edition = "2021"
 [dependencies]
 log = "0.4.8"
 
-[dependencies.irq_safety]
-git = "https://github.com/theseus-os/irq_safety"
+irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
+dfqueue = { path = "../../libs/dfqueue", version = "0.1.0" }
+kernel_config = { path = "../kernel_config" }
+interrupts = { path = "../interrupts" }
+scheduler = { path = "../scheduler" }
+mod_mgmt = { path = "../mod_mgmt" }
+no_drop = { path = "../no_drop" }
+task_fs = { path = "../task_fs" }
+memory = { path = "../memory" }
+spawn = { path = "../spawn" }
+stack = { path = "../stack" }
+task = { path = "../task" }
+cpu = { path = "../cpu" }
 
-[dependencies.dfqueue]
-path = "../../libs/dfqueue"
-version = "0.1.0"
-
-[dependencies.kernel_config]
-path = "../kernel_config"
-
-[dependencies.logger_x86_64]
-path = "../logger_x86_64"
-
-[dependencies.window_manager]
-path = "../window_manager"
-
-[dependencies.first_application]
-path = "../first_application"
-
-[dependencies.memory]
-path = "../memory"
-
-[dependencies.no_drop]
-path = "../no_drop"
-
-[dependencies.stack]
-path = "../stack"
-
-[dependencies.mod_mgmt]
-path = "../mod_mgmt"
-
-[dependencies.exceptions_full]
-path = "../exceptions_full"
-
-[dependencies.tlb_shootdown]
-path = "../tlb_shootdown"
-
-[dependencies.cpu]
-path = "../cpu"
-
-[dependencies.spawn]
-path = "../spawn"
-
-[dependencies.tsc]
-path = "../tsc"
-
-[dependencies.interrupts]
-path = "../interrupts"
-
-[dependencies.acpi]
-path = "../acpi"
-
-[dependencies.multicore_bringup]
-path = "../multicore_bringup"
-
-[dependencies.page_attribute_table]
-path = "../page_attribute_table"
-
-[dependencies.device_manager]
-path = "../device_manager"
-
-[dependencies.e1000]
-path = "../e1000"
-
-[dependencies.task]
-path = "../task"
-
-[dependencies.scheduler]
-path = "../scheduler"
-
-[dependencies.console]
-path = "../console"
-
-[dependencies.app_io]
-path = "../app_io"
-
-[dependencies.vga_buffer]
-path = "../vga_buffer"
-
-[dependencies.network_manager]
-path = "../network_manager"
-
-[dependencies.ota_update_client]
-path = "../ota_update_client"
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+logger_x86_64 = { path = "../logger_x86_64" }
+window_manager = { path = "../window_manager" }
+first_application = { path = "../first_application" }
+exceptions_full = { path = "../exceptions_full" }
+tlb_shootdown = { path = "../tlb_shootdown" }
+multiple_heaps = { path = "../multiple_heaps" }
+tsc = { path = "../tsc" }
+acpi = { path = "../acpi" }
+multicore_bringup = { path = "../multicore_bringup" }
+page_attribute_table = { path = "../page_attribute_table" }
+device_manager = { path = "../device_manager" }
+e1000 = { path = "../e1000" }
+console = { path = "../console" }
+app_io = { path = "../app_io" }
+vga_buffer = { path = "../vga_buffer" }
+network_manager = { path = "../network_manager" }
+ota_update_client = { path = "../ota_update_client" }
 
 ## This should be dependent upon 'cfg(simd_personality)',
 ## but it cannot be because of https://github.com/rust-lang/cargo/issues/5499.
 ## Therefore, it has to be unconditionally included.
-[dependencies.simd_personality]
-path = "../simd_personality"
-
-[dependencies.task_fs]
-path = "../task_fs"
-
-[dependencies.multiple_heaps]
-path = "../multiple_heaps"
+simd_personality = { path = "../simd_personality" }
 
 [features]
 # TODO: Remove when UEFI is fully implemented

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -161,7 +161,7 @@ pub fn init(
         info!("Initialized per-core heaps");
     }
 
-    #[cfg(feature = "uefi")] {
+    #[cfg(all(feature = "uefi", target_arch = "x86_64"))] {
         log::error!("uefi boot cannot proceed as it is not fully implemented");
         loop {}
     }

--- a/kernel/captain/src/lib.rs
+++ b/kernel/captain/src/lib.rs
@@ -19,14 +19,17 @@
 
 extern crate alloc;
 
-use core::ops::DerefMut;
 use log::{error, info};
 use memory::{EarlyIdentityMappedPages, MmiRef, PhysicalAddress, VirtualAddress};
-use kernel_config::memory::KERNEL_STACK_SIZE_IN_PAGES;
 use irq_safety::enable_interrupts;
 use stack::Stack;
 use no_drop::NoDrop;
 
+#[cfg(target_arch = "x86_64")]
+use {
+    core::ops::DerefMut,
+    kernel_config::memory::KERNEL_STACK_SIZE_IN_PAGES,
+};
 
 #[cfg(all(mirror_log_to_vga, target_arch = "x86_64"))]
 mod mirror_log_callbacks {
@@ -69,6 +72,7 @@ impl DropAfterInit {
 /// * `ap_gdt`: the virtual address of the GDT created for the AP's realmode boot code.
 /// * `rsdp_address`: the physical address of the RSDP (an ACPI table pointer),
 ///    if available and provided by the bootloader.
+#[cfg_attr(target_arch = "aarch64", allow(unreachable_code, unused_variables))]
 pub fn init(
     kernel_mmi_ref: MmiRef,
     bsp_initial_stack: NoDrop<Stack>,

--- a/kernel/catch_unwind/Cargo.toml
+++ b/kernel/catch_unwind/Cargo.toml
@@ -4,14 +4,13 @@ name = "catch_unwind"
 description = "Support for catching unwinding after a panic, like `std::panic::catch_unwind`"
 version = "0.1.0"
 
-[dependencies.log]
-version = "0.4.8"
+[dependencies]
+log = "0.4.8"
 
-[dependencies.unwind]
-path = "../unwind"
+task = { path = "../task" }
 
-[dependencies.task]
-path = "../task"
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+unwind = { path = "../unwind" }
 
 [lib]
 crate-type = ["rlib"]

--- a/kernel/catch_unwind/src/lib.rs
+++ b/kernel/catch_unwind/src/lib.rs
@@ -7,8 +7,9 @@ extern crate alloc;
 extern crate task;
 
 use core::mem::ManuallyDrop;
-use alloc::boxed::Box;
 use task::KillReason;
+#[cfg(target_arch = "x86_64")]
+use alloc::boxed::Box;
 
 /// Invokes the given closure `f`, catching a panic as it is unwinding the stack.
 /// 
@@ -52,7 +53,8 @@ pub fn catch_unwind_with_arg<F, A, R>(f: F, arg: A) -> Result<R, KillReason>
 /// # Arguments
 /// * a pointer to the 
 /// * a pointer to the arbitrary object passed around during the unwinding process,
-///   which in Theseus is a pointer to the `UnwindingContext`. 
+///   which in Theseus is a pointer to the `UnwindingContext`.
+#[cfg_attr(target_arch = "aarch64", allow(unused_variables))]
 fn panic_callback<F, A, R>(data_ptr: *mut u8, exception_object: *mut u8) where F: FnOnce(A) -> R {
     #[cfg(not(target_arch = "x86_64"))]
     loop {};
@@ -110,6 +112,7 @@ fn try_intrinsic_trampoline<F, A, R>(try_intrinsic_arg: *mut u8) where F: FnOnce
 ///    represent the possibility of a non-panic failure, e.g., a machine exception.
 /// 
 /// [`std::panic::resume_unwind()`]: https://doc.rust-lang.org/std/panic/fn.resume_unwind.html
+#[cfg_attr(target_arch = "aarch64", allow(unused_variables))]
 pub fn resume_unwind(caught_panic_reason: KillReason) -> ! {
     // We can skip up to 2 frames here: `unwind::start_unwinding` and `resume_unwind` (this function)
     #[cfg(target_arch = "x86_64")]

--- a/kernel/cpu/src/aarch64.rs
+++ b/kernel/cpu/src/aarch64.rs
@@ -4,6 +4,8 @@ use cortex_a::registers::MPIDR_EL1;
 use tock_registers::interfaces::Readable;
 
 use core::fmt;
+use super::CpuId;
+use derive_more::{Display, Binary, Octal, LowerHex, UpperHex};
 
 /// Returns the number of CPUs (SMP cores) that exist and
 /// are currently initialized on this system.

--- a/kernel/crate_metadata_serde/src/lib.rs
+++ b/kernel/crate_metadata_serde/src/lib.rs
@@ -146,4 +146,9 @@ impl SectionType {
     pub fn is_data_or_bss(&self) -> bool {
         matches!(self, Self::Data | Self::Bss)
     }
+
+    /// Returns `true` if `TlsData` or `TlsBss`, otherwise `false`.
+    pub fn is_tls(&self) -> bool {
+        matches!(self, Self::TlsData | Self::TlsBss)
+    }
 }

--- a/kernel/fault_log/Cargo.toml
+++ b/kernel/fault_log/Cargo.toml
@@ -4,26 +4,13 @@ version = "0.1.0"
 description = "Logs all exceptions occuring in Theseus"
 authors = ["Namitha Liyanage <namithaliyanage@gmail.com>"]
 
+[dependencies]
+irq_safety = { git = "https://github.com/theseus-os/irq_safety" }
+memory = { path = "../memory" }
+app_io = { path = "../app_io" }
+task = { path = "../task" }
+cpu = { path = "../cpu" }
+log = { default-features = false, version = "0.4.8" }
 
-[dependencies.irq_safety]
-git = "https://github.com/theseus-os/irq_safety"
-
-[dependencies.memory]
-path = "../memory"
-
-[dependencies.vga_buffer]
-path = "../vga_buffer"
-
-[dependencies.app_io]
-path = "../app_io"
-
-[dependencies.task]
-path = "../task"
-
-[dependencies.cpu]
-path = "../cpu"
-
-[dependencies.log]
-default-features = false
-version = "0.4.8"
-
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+vga_buffer = { path = "../vga_buffer" }

--- a/kernel/fault_log/src/lib.rs
+++ b/kernel/fault_log/src/lib.rs
@@ -6,7 +6,10 @@
 #![no_std]
 #![feature(drain_filter)]
 
-#[macro_use] extern crate vga_buffer; // for println_raw!()
+#[cfg(target_arch = "x86_64")]
+#[macro_use]
+extern crate vga_buffer; // for println_raw!()
+
 #[macro_use] extern crate app_io; // for regular println!()
 #[macro_use] extern crate log;
 extern crate alloc;
@@ -221,11 +224,15 @@ pub fn remove_unhandled_exceptions() -> Vec<FaultEntry> {
 /// calls println!() and then println_raw!()
 macro_rules! println_both {
     ($fmt:expr) => {
+        #[cfg(target_arch = "x86_64")]
         print_raw!(concat!($fmt, "\n"));
+
         print!(concat!($fmt, "\n"));
     };
     ($fmt:expr, $($arg:tt)*) => {
+        #[cfg(target_arch = "x86_64")]
         print_raw!(concat!($fmt, "\n"), $($arg)*);
+
         print!(concat!($fmt, "\n"), $($arg)*);
     };
 }

--- a/kernel/interrupts/src/aarch64/mod.rs
+++ b/kernel/interrupts/src/aarch64/mod.rs
@@ -11,7 +11,7 @@ use tock_registers::registers::InMemoryRegister;
 use gic::{qemu_virt_addrs, ArmGic, InterruptNumber, Version as GicVersion};
 use irq_safety::{RwLockIrqSafe, MutexIrqSafe};
 use memory::get_kernel_mmi_ref;
-use log::{info, error};
+use log::error;
 
 // This assembly file contains trampolines to `extern "C"` functions defined below.
 global_asm!(include_str!("table.s"));
@@ -64,6 +64,7 @@ pub struct ExceptionContext {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[repr(C)]
 pub enum EoiBehaviour {
     CallerMustSignalEoi,
     HandlerHasSignaledEoi,

--- a/kernel/mod_mgmt/src/parse_nano_core.rs
+++ b/kernel/mod_mgmt/src/parse_nano_core.rs
@@ -796,6 +796,9 @@ fn add_new_section(
         )))
     }
     else if main_section_info.tls_data_info.map_or(false, |(shndx, _)| sec_ndx == shndx) {
+        // Skip zero-sized TLS sections, which are just markers, not real sections.
+        if sec_size == 0 { return Ok(()); }
+
         // TLS sections encode their TLS offset in the virtual address field,
         // which is necessary to properly calculate relocation entries that depend upon them.
         let tls_offset = sec_vaddr;
@@ -824,6 +827,9 @@ fn add_new_section(
         Some(tls_section_ref)
     }
     else if main_section_info.tls_bss_info.map_or(false, |(shndx, _)| sec_ndx == shndx) {
+        // Skip zero-sized TLS sections, which are just markers, not real sections.
+        if sec_size == 0 { return Ok(()); }
+
         // TLS sections encode their TLS offset in the virtual address field,
         // which is necessary to properly calculate relocation entries that depend upon them.
         let tls_offset = sec_vaddr;

--- a/kernel/multicore_bringup/src/lib.rs
+++ b/kernel/multicore_bringup/src/lib.rs
@@ -36,7 +36,7 @@ use memory::{VirtualAddress, PhysicalAddress, MappedPages, PteFlags, MmiRef};
 use kernel_config::memory::{PAGE_SIZE, PAGE_SHIFT, KERNEL_STACK_SIZE_IN_PAGES};
 use apic::{LocalApic, get_lapics, current_cpu, has_x2apic, bootstrap_cpu, cpu_count};
 use ap_start::{kstart_ap, AP_READY_FLAG};
-use madt::{Madt, MadtEntry, MadtLocalApic, find_nmi_entry_for_processor};
+use madt::{Madt, MadtEntry, find_nmi_entry_for_processor};
 use pause::spin_loop_hint;
 
 
@@ -240,7 +240,6 @@ pub fn handle_ap_cores(
 
     let all_lapics = get_lapics();
     let this_cpu = current_cpu();
-    let this_cpu_as_u8: Result<u8, _> = this_cpu.value().try_into();
 
     // Copy the AP startup code (from the kernel's text section pages) into the AP_STARTUP physical address entry point.
     {
@@ -275,42 +274,47 @@ pub fn handle_ap_cores(
     let madt_iter = madt.iter();
 
     for madt_entry in madt_iter.clone() {
-        if let MadtEntry::LocalApic(lapic_entry) = madt_entry { 
-            if let Ok(this_cpu_as_u8) = this_cpu_as_u8 && this_cpu_as_u8 == lapic_entry.apic_id {
-                // debug!("skipping BSP's local apic");
-            }
-            else {
-                if lapic_entry.flags & 0x1 != 0x1 {
-                    warn!("Processor {} apic_id {} is disabled by the hardware, cannot initialize or use it.", 
-                            lapic_entry.processor, lapic_entry.apic_id);
-                    continue;
-                }
+        let (processor_id, apic_id, flags) = match madt_entry {
+            MadtEntry::LocalApic(entry) => (entry.processor as u32, entry.apic_id as u32, entry.flags),
+            MadtEntry::LocalX2Apic(entry) => (entry.processor, entry.x2apic_id, entry.flags),
+            _ => continue,
+        };
 
-                // start up this AP, and have it create a new LocalApic for itself. 
-                // This must be done by each core itself, and not called repeatedly by the BSP on behalf of other cores.
-                let bsp_lapic_ref = bootstrap_cpu()
-                    .and_then(|bsp_id| all_lapics.get(&bsp_id))
-                    .ok_or("Couldn't get BSP's LocalApic!")?;
-                let mut bsp_lapic = bsp_lapic_ref.write();
-                let ap_stack = stack::alloc_stack(
-                    KERNEL_STACK_SIZE_IN_PAGES,
-                    &mut kernel_mmi_ref.lock().page_table,
-                ).ok_or("could not allocate AP stack!")?;
-
-                let (nmi_lint, nmi_flags) = find_nmi_entry_for_processor(lapic_entry.processor, madt_iter.clone());
-
-                bring_up_ap(
-                    bsp_lapic.deref_mut(), 
-                    lapic_entry,
-                    ap_trampoline_data,
-                    page_table_phys_addr, 
-                    ap_stack, 
-                    nmi_lint,
-                    nmi_flags 
-                );
-                ap_count += 1;
-            }
+        // we already handled the BSP in a different functions
+        if this_cpu.value() == apic_id {
+            continue;
         }
+
+        if flags & 0x1 != 0x1 {
+            warn!("Processor {} apic_id {} is disabled by the hardware, cannot initialize or use it.", 
+                processor_id, apic_id);
+            continue;
+        }
+
+        // start up this AP, and have it create a new LocalApic for itself. 
+        // This must be done by each core itself, and not called repeatedly by the BSP on behalf of other cores.
+        let bsp_lapic_ref = bootstrap_cpu()
+            .and_then(|bsp_id| all_lapics.get(&bsp_id))
+            .ok_or("Couldn't get BSP's LocalApic!")?;
+        let mut bsp_lapic = bsp_lapic_ref.write();
+        let ap_stack = stack::alloc_stack(
+            KERNEL_STACK_SIZE_IN_PAGES,
+            &mut kernel_mmi_ref.lock().page_table,
+        ).ok_or("could not allocate AP stack!")?;
+
+        let (nmi_lint, nmi_flags) = find_nmi_entry_for_processor(processor_id, madt_iter.clone());
+
+        bring_up_ap(
+            bsp_lapic.deref_mut(), 
+            processor_id,
+            apic_id,
+            ap_trampoline_data,
+            page_table_phys_addr, 
+            ap_stack, 
+            nmi_lint,
+            nmi_flags 
+        );
+        ap_count += 1;
     }
 
     // Retrieve the graphic mode information written during the AP bootup sequence in `ap_realmode.asm`.
@@ -352,8 +356,8 @@ struct ApTrampolineData {
     /// The Rust setup code sets it to 0, and the AP boot code sets it to 1.
     ap_ready:          Volatile<u64>,
     /// The processor ID of the new AP that is being brought up.
-    ap_processor_id:   Volatile<u8>,
-    _padding0:         [u8; 7],
+    ap_processor_id:   Volatile<u32>,
+    _padding0:         [u8; 4],
     /// The CPU ID of the new AP that is being brought up.
     ap_cpu_id:         Volatile<u32>,
     _padding1:         [u8; 4],
@@ -387,19 +391,19 @@ const _: () = assert!(size_of::<ApTrampolineData>() == 12 * size_of::<u64>());
 
 
 /// Called by the BSP to initialize the given `new_lapic` using IPIs.
+#[allow(clippy::too_many_arguments)]
 fn bring_up_ap(
     bsp_lapic: &mut LocalApic,
-    new_lapic: &MadtLocalApic, 
+    new_apic_processor_id: u32,
+    new_apic_id: u32,
     ap_trampoline_data: &mut ApTrampolineData,
     page_table_paddr: PhysicalAddress, 
     ap_stack: stack::Stack,
     nmi_lint: u8, 
     nmi_flags: u16
 ) {
-    let new_apic_id = new_lapic.apic_id as u32; 
-
     ap_trampoline_data.ap_ready.write(0);
-    ap_trampoline_data.ap_processor_id.write(new_lapic.processor);
+    ap_trampoline_data.ap_processor_id.write(new_apic_processor_id);
     ap_trampoline_data.ap_cpu_id.write(new_apic_id);
     ap_trampoline_data.ap_page_table.write(page_table_paddr);
     ap_trampoline_data.ap_stack_start.write(ap_stack.bottom());
@@ -413,7 +417,7 @@ fn bring_up_ap(
     // in which the AP will take ownership of it once it boots up.
     ap_start::insert_ap_stack(new_apic_id, ap_stack); 
 
-    info!("Bringing up AP, proc: {} apic_id: {}", new_lapic.processor, new_apic_id);
+    info!("Bringing up AP, proc: {} apic_id: {}", new_apic_processor_id, new_apic_id);
     
     bsp_lapic.clear_error();
     let esr = bsp_lapic.error();

--- a/kernel/nano_core/Cargo.toml
+++ b/kernel/nano_core/Cargo.toml
@@ -24,10 +24,10 @@ mod_mgmt = { path = "../mod_mgmt" }
 panic_entry = { path = "../panic_entry" }
 memory_initialization = { path = "../memory_initialization" }
 boot_info = { path = "../boot_info" }
+captain = { path = "../captain" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 exceptions_early = { path = "../exceptions_early" }
-captain = { path = "../captain" }
 serial_port_basic = { path = "../serial_port_basic" }
 vga_buffer = { path = "../vga_buffer" }
 logger_x86_64 = { path = "../logger_x86_64" }

--- a/kernel/nano_core/src/lib.rs
+++ b/kernel/nano_core/src/lib.rs
@@ -23,11 +23,14 @@ extern crate panic_entry;
 
 use core::ops::DerefMut;
 use memory::VirtualAddress;
-use kernel_config::memory::KERNEL_OFFSET;
 use mod_mgmt::parse_nano_core::NanoCoreItems;
 
 #[cfg(target_arch = "x86_64")]
-use vga_buffer::println_raw;
+use {
+    vga_buffer::println_raw,
+    kernel_config::memory::KERNEL_OFFSET,
+};
+
 #[cfg(target_arch = "aarch64")]
 use log::info as println_raw;
 

--- a/kernel/scheduler/src/lib.rs
+++ b/kernel/scheduler/src/lib.rs
@@ -24,7 +24,7 @@ cfg_if::cfg_if! {
     }
 }
 
-use interrupts::{self, CPU_LOCAL_TIMER_IRQ, eoi, register_interrupt};
+use interrupts::{self, CPU_LOCAL_TIMER_IRQ, eoi};
 use task::{self, TaskRef};
 
 /// A re-export of [`task::schedule()`] for convenience and legacy compatibility.
@@ -44,7 +44,7 @@ pub fn init() -> Result<(), &'static str> {
     task::set_scheduler_policy(scheduler::select_next_task);
 
     #[cfg(target_arch = "x86_64")] {
-        register_interrupt(
+        interrupts::register_interrupt(
             CPU_LOCAL_TIMER_IRQ,
             lapic_timer_handler,
         ).map_err(|_handler| {

--- a/kernel/tls_initializer/src/lib.rs
+++ b/kernel/tls_initializer/src/lib.rs
@@ -5,6 +5,10 @@
 //!    in order to correctly generate new TLS data images.
 //! 2. [`TlsDataImage`]: a generated TLS data image that can be used as the TLS area
 //!    for a single task.
+//!
+//! TODO FIXME: currently we are unsure of the `virt_addr_value`s calculated 
+//!             for TLS sections on aarch64. The placement of those sections in the
+//!             TLS data image is correct, but relocations against them may not be.
 
 #![no_std]
 #![feature(int_roundings)]
@@ -48,7 +52,6 @@ pub struct TlsInitializer {
     ///
     /// On aarch64, the ELF TLS ABI specifies only positive offsets,
     /// and there is no TLS self pointer.
-    /// * TODO: not sure about this claim. *
     static_section_offsets:  RangeMap<usize, StrongSectionRefWrapper>,
     /// The ending offset (an exclusive range end bound) of the last TLS section
     /// in the above set of `static_section_offsets`.
@@ -56,16 +59,27 @@ pub struct TlsInitializer {
     end_of_static_sections: usize,
     /// The set of TLS data sections that come from dynamically-loaded crate object files.
     /// We can control and arbitrarily assign their offsets, and thus,
-    /// we place all of these sections **after** the TLS self pointer in memory.
-    /// For example, the first section in this set (with an offset of `0`) will be place
-    /// right after the TLS self pointer in memory.
+    /// we place all of these sections **after** the static sections
+    /// in the generated TLS data image.
+    ///
+    /// * On x86_64, these are placed right after the TLS self pointer,
+    ///   which itself is right after the static TLS sections.
+    /// * On aarch64, these are placed directly after the static TLS sections,
+    ///   as there is no TLS self pointer.
     dynamic_section_offsets: RangeMap<usize, StrongSectionRefWrapper>,
     /// The ending offset (an exclusive range end bound) of the last TLS section
     /// in the above set of `dynamic_section_offsets`.
     end_of_dynamic_sections: usize,
 } 
 
-const POINTER_SIZE: usize = size_of::<usize>();
+/// On x86_64, a TLS self pointer exists at the 0th index/offset into each TLS data image,
+/// which is just a pointer to itself.
+#[cfg(target_arch = "x86_64")]
+const TLS_SELF_POINTER_SIZE: usize = size_of::<usize>();
+
+/// On aarch64, there is no TLS self pointer.
+#[cfg(target_arch = "aarch64")]
+const TLS_SELF_POINTER_SIZE: usize = 0;
 
 impl TlsInitializer {
     /// Creates an empty TLS initializer with no TLS data sections.
@@ -92,12 +106,13 @@ impl TlsInitializer {
     ///   all the static TLS sections, i.e., where the TLS self pointer exists in memory,
     ///   to the start of this section in the TLS image.
     ///   * `VirtAddr = -1 * (total_static_tls_size - offset);`
-    /// * On aarch64, that value will be a positive offset from the beginning
-    ///   of all sections, i.e., the start of the TLS data image,
-    ///   to the start of this section in the TLS image,
-    ///   _plus_ another value that is the max of 16 (0x10) and the alignment of
-    ///   this section's containing TLS segment.
-    ///   * `VirtAddr = max(16, TLS_segment_align) + offset;`
+    /// * On aarch64, that value will simply be the given `offset`.
+    ///   * `VirtAddr = offset;`.
+    ///   * However, on aarch64, the actual *location* of this section in the TLS data image
+    ///     is given by `offset + max(16, TLS_segment_align)`.
+    ///     The ELF TLS ABI on aarch64 specifies that this augmented value is
+    ///     the real offset used to *access* this TLS variable from the TLS base address
+    ///     (from the beginning of all sections).
     ///
     /// ## Arguments
     /// * `tls_section`: the TLS section present in base kernel image.
@@ -118,6 +133,11 @@ impl TlsInitializer {
         offset: usize,
         total_static_tls_size: usize,
     ) -> Result<StrongSectionRef, ()> {
+        #[cfg(target_arch = "aarch64")]
+        let original_offset = offset;
+        #[cfg(target_arch = "aarch64")]
+        let offset = max(16, 8 /* TODO FIXME: pass in the TLS segment's alignment */) + offset;
+
         let range = offset .. (offset + tls_section.size);
         if self.static_section_offsets.contains_key(&range.start) || 
             self.static_section_offsets.contains_key(&(range.end - 1))
@@ -127,11 +147,12 @@ impl TlsInitializer {
 
         // Calculate the new value of this section's virtual address based on its offset.
         #[cfg(target_arch = "x86_64")]
-        let starting_offset = (total_static_tls_size - offset).wrapping_neg();
-        #[cfg(target_arch = "aarch64")]
-        let starting_offset = max(16, 8 /* TODO FIXME: pass in the TLS segment's alignment */) + offset;
+        let virt_addr_value = (total_static_tls_size - offset).wrapping_neg();
 
-        tls_section.virt_addr = VirtualAddress::new(starting_offset).ok_or(())?;
+        #[cfg(target_arch = "aarch64")]
+        let virt_addr_value = original_offset;
+
+        tls_section.virt_addr = VirtualAddress::new(virt_addr_value).ok_or(())?;
         self.end_of_static_sections = max(self.end_of_static_sections, range.end);
         let section_ref = Arc::new(tls_section);
         self.static_section_offsets.insert(range, StrongSectionRefWrapper(section_ref.clone()));
@@ -141,19 +162,16 @@ impl TlsInitializer {
 
     /// Inserts the given `section` into this TLS area at the next index
     /// (i.e., offset into the TLS area) where the section will fit.
-    /// 
+    ///
     /// This also modifies the virtual address field of the given `section`
-    /// to hold the value of that offset, which is necessary for relocation entries
-    /// that depend on this section.
-    /// 
-    /// Note: this will never return an index/offset value less than `size_of::<usize>()`,
-    /// (`8` on a 64-bit machine), as the first slot is reserved for the TLS self pointer.
-    /// 
+    /// to hold the proper value based on that offset, which is necessary
+    /// for calculating relocation entries that depend on this section.
+    ///
     /// Returns a tuple of:
     /// 1. The index at which the new section was inserted, 
     ///    which is the offset from the beginning of the TLS area where the section data starts.
     /// 2. The modified section as a `StrongSectionRef`.
-    /// 
+    ///
     /// Returns an Error if there is no remaining space that can fit the section.
     pub fn add_new_dynamic_tls_section(
         &mut self,
@@ -161,10 +179,16 @@ impl TlsInitializer {
         alignment: usize,
     ) -> Result<(usize, StrongSectionRef), ()> {
         let mut start_index = None;
-        // Find the next "gap" big enough to fit the new TLS section, 
-        // skipping the first `POINTER_SIZE` bytes, which are reserved for the TLS self pointer.
-        let range_after_tls_self_pointer = POINTER_SIZE .. usize::MAX;
-        for gap in self.dynamic_section_offsets.gaps(&range_after_tls_self_pointer) {
+        // First, we find the next "gap" big enough to fit the new TLS section.
+        // On x86_64, we skip the first `TLS_SELF_POINTER_SIZE` bytes, reserved for the TLS self pointer.
+        #[cfg(target_arch = "x86_64")]
+        let start_of_search: usize = TLS_SELF_POINTER_SIZE;
+
+        // On aarch64, the ELF TLS ABI specifies that we must 
+        #[cfg(target_arch = "aarch64")]
+        let start_of_search: usize = max(16, 8 /* TODO FIXME: pass in the TLS SEGMENT's alignment (not the section's alignment)*/);
+
+        for gap in self.dynamic_section_offsets.gaps(&(start_of_search .. usize::MAX)) {
             let aligned_start = gap.start.next_multiple_of(alignment);
             if aligned_start + section.size <= gap.end {
                 start_index = Some(aligned_start);
@@ -173,8 +197,16 @@ impl TlsInitializer {
         }
 
         let start = start_index.ok_or(())?;
+
+        // Calculate this section's virtual address based the range we reserved for it.
+        #[cfg(target_arch = "x86_64")]
+        let virt_addr_value = start;
+
+        #[cfg(target_arch = "aarch64")]
+        let virt_addr_value = start + self.end_of_static_sections - max(16, 8 /* TODO FIXME: pass in the TLS segment's alignment */);
+
+        section.virt_addr = VirtualAddress::new(virt_addr_value).ok_or(())?;
         let range = start .. (start + section.size);
-        section.virt_addr = VirtualAddress::new(range.start).ok_or(())?;
         let section_ref = Arc::new(section);
         self.end_of_dynamic_sections = max(self.end_of_dynamic_sections, range.end);
         self.dynamic_section_offsets.insert(range, StrongSectionRefWrapper(section_ref.clone()));
@@ -193,11 +225,11 @@ impl TlsInitializer {
     }
 
     /// Returns a new copy of the TLS data image.
-    /// 
+    ///
     /// This function lazily generates the TLS image data on demand, if needed.
     pub fn get_data(&mut self) -> TlsDataImage {
         let total_section_size = self.end_of_static_sections + self.end_of_dynamic_sections;
-        let required_capacity = if total_section_size > 0 { total_section_size + POINTER_SIZE } else { 0 };
+        let required_capacity = if total_section_size > 0 { total_section_size + TLS_SELF_POINTER_SIZE } else { 0 };
         if required_capacity == 0 {
             return TlsDataImage { _data: None, ptr: 0 };
         }
@@ -227,7 +259,7 @@ impl TlsInitializer {
         }
 
         if self.cache_status == CacheStatus::Invalidated {
-            // debug!("TlsInitializer was invalidated, re-generating data.\n{:#X?}", self);
+            // log::debug!("TlsInitializer was invalidated, re-generating data.\n{:#X?}", self);
 
             // On some architectures, such as x86_64, the ABI convention REQUIRES that
             // the TLS area data starts with a pointer to itself (the TLS self pointer).
@@ -237,6 +269,8 @@ impl TlsInitializer {
             // to the `new_data` vector after we insert the static TLS data sections.
             // The location of the new pointer value is the conceptual "start" of the TLS image,
             // and that's what should be used for the value of the TLS register (e.g., `FS_BASE` MSR on x86_64).
+            //
+            // On aarch64, `TLS_SELF_POINTER_SIZE` is 0, so this is still correct.
             let mut new_data: Vec<u8> = Vec::with_capacity(required_capacity);
             
             // Iterate through all static TLS sections and copy their data into the new data image.
@@ -246,10 +280,12 @@ impl TlsInitializer {
 
             // Append space for the TLS self pointer immediately after the end of the last static TLS data section;
             // its actual value will be filled in later (in `get_data()`) after a new copy of the TLS data image is made.
-            new_data.extend_from_slice(&[0u8; POINTER_SIZE]);
+            #[cfg(target_arch = "x86_64")]
+            new_data.extend_from_slice(&[0u8; TLS_SELF_POINTER_SIZE]);
 
             // Iterate through all dynamic TLS sections and copy their data into the new data image.
-            end_of_previous_range = POINTER_SIZE; // we already pushed room for the TLS self pointer above.
+            // If needed (as on x86_64), we already pushed room for the TLS self pointer above.
+            end_of_previous_range = TLS_SELF_POINTER_SIZE;
             copy_tls_section_data(&mut new_data, &self.dynamic_section_offsets, &mut end_of_previous_range);
             if self.end_of_dynamic_sections != 0 {
                 // this assertion only makes sense if there are any dynamic sections
@@ -261,21 +297,33 @@ impl TlsInitializer {
         }
 
         // Here, the `data_cache` is guaranteed to be fresh and ready to use.
-        let mut data_copy: Box<[u8]> = self.data_cache.as_slice().into();
-        // Every time we create a new copy of the TLS data image, we have to re-calculate
-        // and re-assign the TLS self pointer value (located after the static TLS section data),
-        // because the virtual address of that new TLS data image copy will be unique.
-        // Note that we only do this if the data_copy actually contains any TLS data.
-        let self_ptr_offset = self.end_of_static_sections;
-        if let Some(dest_slice) = data_copy.get_mut(self_ptr_offset .. (self_ptr_offset + POINTER_SIZE)) {
+        #[cfg(target_arch = "x86_64")] {
+            let mut data_copy: Box<[u8]> = self.data_cache.as_slice().into();
+            // Every time we create a new copy of the TLS data image, we have to re-calculate
+            // and re-assign the TLS self pointer value (located after the static TLS section data),
+            // because the virtual address of that new TLS data image copy will be unique.
+            // Note that we only do this if the data_copy actually contains any TLS data.
+            let self_ptr_offset = self.end_of_static_sections;
+            let Some(dest_slice) = data_copy.get_mut(
+                self_ptr_offset .. (self_ptr_offset + TLS_SELF_POINTER_SIZE)
+            ) else {
+                panic!("BUG: offset of TLS self pointer was out of bounds in the TLS data image:\n{:02X?}", data_copy);
+            };
             let tls_self_ptr_value = dest_slice.as_ptr() as usize;
             dest_slice.copy_from_slice(&tls_self_ptr_value.to_ne_bytes());
             TlsDataImage {
                 _data: Some(data_copy),
                 ptr:   tls_self_ptr_value,
             }
-        } else {
-            panic!("BUG: offset of TLS self pointer was out of bounds in the TLS data image:\n{:02X?}", data_copy);
+        }
+
+        #[cfg(target_arch = "aarch64")] {
+            let data_copy: Box<[u8]> = self.data_cache.as_slice().into();
+            let ptr = data_copy.as_ptr() as usize;
+            TlsDataImage {
+                _data: Some(data_copy),
+                ptr,
+            }
         }
     }
 }

--- a/kernel/tls_initializer/src/lib.rs
+++ b/kernel/tls_initializer/src/lib.rs
@@ -16,13 +16,16 @@
 extern crate alloc;
 
 use alloc::{sync::Arc, vec::Vec, boxed::Box};
-use core::{mem::size_of, cmp::max, ops::Deref};
+use core::{cmp::max, ops::Deref};
 use crate_metadata::{LoadedSection, SectionType, StrongSectionRef};
 use memory_structs::VirtualAddress;
 use rangemap::RangeMap;
 
 #[cfg(target_arch = "x86_64")]
-use x86_64::{registers::model_specific::FsBase, VirtAddr};
+use {
+    core::mem::size_of,
+    x86_64::{registers::model_specific::FsBase, VirtAddr},
+};
 
 #[cfg(target_arch = "aarch64")]
 use {
@@ -127,6 +130,7 @@ impl TlsInitializer {
     ///   would overlap with an existing section. 
     ///   An error occurring here would indicate a link-time bug 
     ///   or a bug in the symbol parsing code that invokes this function.
+    #[cfg_attr(target_arch = "aarch64", allow(unused_variables))]
     pub fn add_existing_static_tls_section(
         &mut self,
         mut tls_section: LoadedSection,


### PR DESCRIPTION
This contains three changes:
- `nano_core` depends on `captain` and jumps to it just like on x86_64
- `captain::init` calls are almost entirely arch-gated
- preemptive scheduling is enabled